### PR TITLE
Setup client api version

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const GhostAdminApi = require('@tryghost/admin-api');
         const api = new GhostAdminApi({
             url,
             key: core.getInput('api-key'),
-            version: 'v5.0'
+            version: core.getInput('client-api-version') || 'v5.0'
         });
         const workingDir = core.getInput('working-directory');
         const basePath = path.join(process.env.GITHUB_WORKSPACE, workingDir);


### PR DESCRIPTION
Add ability to set up API version. 

This is related to this error:
![Screenshot 2024-06-25 at 10 52 10 AM](https://github.com/yininge/action-deploy-theme/assets/31861992/d745d92b-9b04-4c37-9f37-bc37fabdba88)